### PR TITLE
Adding 'success' case in check_sim_status 

### DIFF
--- a/nexus/lib/pwscf.py
+++ b/nexus/lib/pwscf.py
@@ -292,6 +292,7 @@ class Pwscf(Simulation):
         output = fobj.read()
         fobj.close()
         not_converged = 'convergence NOT achieved'  in output
+        data_written  = 'Writing output data file' in output
         time_exceeded = 'Maximum CPU time exceeded' in output
         user_stop     = 'Program stopped by user request' in output
         run_finished  = 'JOB DONE' in output
@@ -308,10 +309,17 @@ class Pwscf(Simulation):
             self.input.control.restart_mode = 'restart'
             self.reset_indicators()
         else:
+
+            # Failure case
+
             definite_failure |= not_converged
             definite_failure |= time_exceeded
             definite_failure |= user_stop
             definite_failure |= not run_finished
+
+            # Success cases
+
+            definite_success |= data_written and not user_stop
 
             if definite_failure:
                 self.failed = True

--- a/nexus/lib/simulation.py
+++ b/nexus/lib/simulation.py
@@ -1080,7 +1080,7 @@ class Simulation(NexusCore):
             self.finished = self.job.finished
         else:
             if not self.job.finished and self.process_id is not None:
-                machine = job.get_machine()
+                machine = self.job.get_machine()
                 if isinstance(machine,Supercomputer):
                     self.job.finished = self.process_id not in machine.system_queue
                 #end if


### PR DESCRIPTION
We seem to have forgotten to code a case where 'definite_success' is true. I suppose this is 'correct' since it seems difficult to determine success with certainty, but we have to take a gamble somewhere in order to not always fail.

For the moment, I am working under the assumption that when the output contains 'Writing output data file' and the run was NOT stopped by the user, then the run succeeded.

